### PR TITLE
Added copy code button to CodeBlock - not for merging

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -11,6 +11,7 @@
     export let weight: string = 'ring-1';
     export let width: string = 'w-auto';
     export let rounded: string = 'rounded-lg';
+	export let hidden: boolean = false;
 
     // Set tag and href values
     const tag: string = $$props.href ? 'a' : 'button';
@@ -97,8 +98,9 @@
 
 <svelte:element
     this={tag}
-    class="comp-button {classesButton} {$$props.class}"
+	class="comp-button {classesButton} {$$props.class ? $$props.class : ''}"
     {href}
+	class:hidden={hidden}
     data-testid="comp-button"
     on:click
     {...prunedRestProps()}

--- a/src/lib/CodeBlock/CodeBlock.svelte
+++ b/src/lib/CodeBlock/CodeBlock.svelte
@@ -1,22 +1,52 @@
 <script lang="ts">
     import hljs from 'highlight.js';
-    
+	import Button from '$lib/Button/Button.svelte';
+
     export let language: string = 'plaintext';
     export let code: string = '';
+	export let variant:string = 'ghost';
+
+	let hideCopyButton: boolean = true;
+	let toggleCopyButtonVisibility = () => { hideCopyButton = !hideCopyButton}
+	let computedVariant:string = variant
+	let showCopiedMessage:boolean = false;
 
     // Base Classes
     let cBaseBlock: string = `bg-surface-700 dark:bg-black/20 text-surface-50 p-4 rounded`;
-    let cBaseHeader: string = 'text-xs opacity-50 pb-2';
+    let cBaseHeader: string = 'flex justify-between text-xs opacity-50 pb-2 h-8';
 
     function languageFormatter(lang: string): string {
         if (lang === 'js') { return 'javascript'; }
         return lang;
     }
+
+	// Set the copy code button back to normal
+	let timeoutAutoRevert: any;
+
+	function copyCode(){
+		if (navigator.clipboard) {
+			navigator.clipboard.writeText(code);
+			computedVariant = variant + '-primary';
+			showCopiedMessage = true;
+			clearTimeout(timeoutAutoRevert);
+			timeoutAutoRevert = setTimeout(revertCopyCodeButton, 3000);
+		}
+	}
+
+	function revertCopyCodeButton(){
+		computedVariant = variant;
+		showCopiedMessage = false;
+	}
 </script>
 
 {#if language && code}
-<div class="codeblock {cBaseBlock} {$$props.class}" data-testid="codeblock">
-<header class="{cBaseHeader}">{languageFormatter(language)}</header>
+<div class="codeblock {cBaseBlock} {$$props.class}" data-testid="codeblock" on:mouseenter="{toggleCopyButtonVisibility}" on:mouseleave="{toggleCopyButtonVisibility}">
+<header class="{cBaseHeader}">
+	{languageFormatter(language)} 
+	<Button variant={computedVariant} size="sm" bind:hidden={hideCopyButton} on:click={copyCode}>
+		{#if showCopiedMessage} Copied! {:else} Copy {/if}
+	</Button>
+</header>
 <pre class="whitespace-pre-wrap text-base overflow-x-auto">
 <code class="language-{language} outline-none" contenteditable spellcheck="false">{@html hljs.highlight(code, { language }).value || code}</code>
 </pre>


### PR DESCRIPTION
Added 'hidden' prop to Button to assist with auto show/hide
Fixed 'undefined' being output to the class attribute on Button when no class was set on original component.

It shows on rollover of the CodeBlock, updates to reflect user has clicked it and then reverts after 3 seconds.

Mobile is being a bit pesky at the moment - on iOS, the click will not change the colour, yet it will copy the code....  It also causes the page to reload and go to the top....  so if I could get some pointers on this one, much appreciated.

Also, despite everything looking beautiful in VS Code, it clearly has munged up the tab/spacing from that of the project.  If you could let me know what settings/extensions/tools the project is using, then I will update and re-send the PR properly.