### PR TITLE
Added custom typescript exports on package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite dev --port 3000",
 		"build": "vite build",
-		"package": "svelte-kit package",
+		"package": "svelte-kit package && sh scripts/append-types.sh",
 		"patch-package": "npm version patch && svelte-kit package",
 		"publish": "npm publish ./package",
 		"preview": "vite preview",

--- a/scripts/append-types.sh
+++ b/scripts/append-types.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat src/lib/custom.d.ts >> package/index.d.ts
+rm package/custom.d.ts

--- a/src/lib/custom.d.ts
+++ b/src/lib/custom.d.ts
@@ -1,0 +1,2 @@
+// Custom exports
+export { type DialogAlert, type DialogConfirm, type DialogPrompt } from "./Notifications/Stores"

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 // Components ---
 
 export { default as AccordionGroup } from "./Accordion/AccordionGroup.svelte";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"declaration": true,
 		"moduleResolution": "node",


### PR DESCRIPTION
This little script will append the custom exports in src/lib/custom.d.ts to the auto generated package/index.d.ts created by svelte-kit package.

The real fix needs to be upstream, but `svelte-kit package` is marked as experimental and not likely to be improved until after the v1 release of SK