### PR TITLE
Unset class prop will emit undefined

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -97,7 +97,7 @@
 
 <svelte:element
     this={tag}
-    class="comp-button {classesButton} {$$props.class}"
+    class="comp-button {classesButton} {$$props.class ? $$props.class : '' }"
     {href}
     data-testid="comp-button"
     on:click


### PR DESCRIPTION
Most buttons currently emit undefined as the last class if they do not have a class explicitly defined on them in the source.