### PR TITLE
Added NavItem component export

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -21,6 +21,7 @@ export { default as ListItem } from "./List/ListItem.svelte";
 export { default as LogoCloud } from "./LogoCloud/LogoCloud.svelte";
 export { default as Logo } from "./LogoCloud/Logo.svelte";
 export { default as Menu } from "./Menu/Menu.svelte";
+export { default as NavItem } from "./List/NavItem.svelte";
 export { default as Paginator } from "./Paginator/Paginator.svelte";
 export { default as ProgressBar } from "./Progress/ProgressBar.svelte";
 export { default as ProgressRadial } from "./Progress/ProgressRadial.svelte";


### PR DESCRIPTION
Following along with the [Menu](https://skeleton.brainandbonesllc.com/components/menus) documentation and I noticed the `NavItem` component wasn't being exported by default.