### PR TITLE
Decouple Skeleton from SvelteKit

### DIFF
--- a/src/lib/LightSwitch/LightSwitch.svelte
+++ b/src/lib/LightSwitch/LightSwitch.svelte
@@ -1,7 +1,7 @@
 <!-- https://tailwindcss.com/docs/dark-mode -->
 
 <script lang="ts">
-    import { browser } from "$app/env";
+    import { onMount } from "svelte";
 
 	import Card from "$lib/Card/Card.svelte";
 	import List from "$lib/List/List.svelte";
@@ -13,6 +13,13 @@
     export let origin: string = 'auto'; // tl | tr | bl | br
     export let duration: number = 100; // ms
     export let disabled: boolean = false;
+
+    let browser: boolean = false;
+    onMount(() =>{
+        // lifecycle functions don't run during SSR
+        browser = true
+        setThemeClass();
+    });
 
 	let currentTheme: string = 'load';
 	let svg: any = {

--- a/src/lib/Menu/Menu.svelte
+++ b/src/lib/Menu/Menu.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import { onMount, afterUpdate } from "svelte";
-    import { navigating } from "$app/stores";
+    import { onDestroy, onMount, afterUpdate } from "svelte";
     import { fade } from 'svelte/transition';
 
     export let select: boolean = false;
@@ -87,7 +86,11 @@
             scrollParent.addEventListener('scroll', setAutoOrigin);
         }
 	});
-    if ($navigating) { open = false; } // close when navigating
+
+    onDestroy(() => {
+        // close when navigating
+        open = false;
+    });
 
     // Responsive Classes
     $: classesMenu = `${cBaseMenu}`;


### PR DESCRIPTION
I'm playing with Skeleton in a regular Svelte app and made these changes to get it to work for me, so I thought I might as well open a PR.

As suggested in #68, this replaces SvelteKit-specific options with regular lifecyle hooks. 

I've checked out the LightSwitch and Menu running the site locally from this branch, and they seem to work fine. However, I have almost zero experience with SvelteKit. I'm happy to put a bit more time into this, if you have any improvements or an easy way to test this properly, let me know! And if you want to just close it, that's fine too, of course.