### PR TITLE
Explicitly add dependency for @testing-library/dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@sveltejs/adapter-static": "^1.0.0-next.29",
 		"@sveltejs/kit": "^1.0.0-next.322",
 		"@tailwindcss/forms": "^0.5.2",
+		"@testing-library/dom": "^8.17.1",
 		"@testing-library/svelte": "^3.1.1",
 		"@typescript-eslint/eslint-plugin": "^5.25.0",
 		"@typescript-eslint/parser": "^5.25.0",


### PR DESCRIPTION
Allows pnpm users to test straight out of the gate without having to additionally install @testing-library/dom