### PR TITLE
Shell script for quickly creating a Skeleton app

### DIFF
--- a/scripts/skel
+++ b/scripts/skel
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Usage: skel my-new-app
+# Auto-runs Svelte-Kit + Tailwind + Skeleton setup to make it a one liner for setting a up a fresh Skeleton app.
+# Either call this script directly, or preferably drop it into a bin directory that is in your $PATH. You need jq, pnpm installed as well
+# Most likely you should tweak the options depending on what you are testing.
+
+npm init @svelte-add/kit@latest $1 -y -- --with typescript+eslint+prettier+tailwindcss --install --tailwindcss-forms --tailwindcss-typography
+cd $1/
+echo "$( jq '.devDependencies += {"@brainandbones/skeleton":"*"}' package.json )" > package.json
+cat <<EOT > tailwind.config.cjs
+const typography = require('@tailwindcss/typography');
+const forms = require('@tailwindcss/forms');
+const skeleton = require('@brainandbones/skeleton/tailwind.cjs');
+
+const config = {
+	content: ['./src/**/*.{html,js,svelte,ts}', './node_modules/@brainandbones/skeleton/**/*.{html,js,svelte,ts}'],
+
+	theme: {
+		extend: {}
+	},
+
+	plugins: [forms, typography, skeleton]
+};
+
+module.exports = config;
+EOT
+curl -s -o src/theme.css https://raw.githubusercontent.com/Brain-Bones/skeleton/master/src/themes/theme-skeleton.css
+cat <<EOT > src/routes/__layout.svelte
+<script>
+	import '../theme.css'
+	import '../app.css';
+</script>
+
+<slot />
+EOT
+pnpm i


### PR DESCRIPTION
More for contributors/testers - but makes it much simpler to setup a base Skeleton app for testing.

I know the end goal would be more along the lines of a plugin for svelte-add, but there is a lot of complexity involved in doing so as it uses a full on AST to properly insert it's changes rather than the naive string manipulation this script does.  But this definitely helps in the short term.