### PR TITLE
Stripped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte3": "^3.4.1",
 		"jsdom": "^19.0.0",
+		"micromatch": "^4.0.5",
 		"palettey": "^1.0.2",
 		"postcss": "^8.4.16",
 		"postcss-load-config": "^3.1.4",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,9 +1,11 @@
 // import adapter from '@sveltejs/adapter-auto';
 import adapter from '@sveltejs/adapter-static';
 import preprocess from 'svelte-preprocess';
+import mm from 'micromatch';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	
 	// Consult https://github.com/sveltejs/svelte-preprocess
 	// for more information about preprocessors
 	preprocess: [
@@ -19,8 +21,13 @@ const config = {
 			assets: 'build',
 			fallback: 'index.html', // index.html (SPA) | null (SSR)
 			precompress: false
-		})
-		// vite: { ...moved to vite.config.js... }
+		}),
+		package: {
+			// strip test files from packaging
+			files: (filepath) => {
+				return !mm.contains(filepath, 'test');
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
Looking at https://kit.svelte.dev/docs/configuration#package

Their docs are wrong - it needs to be nested under kit.package: and the `'!**/build.*'` exclude is nonsense as they never get sent to that function on either `build` or `package`

This closed #127 