### PR TITLE
JS only version of test strip

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,8 +19,13 @@ const config = {
 			assets: 'build',
 			fallback: 'index.html', // index.html (SPA) | null (SSR)
 			precompress: false
-		})
-		// vite: { ...moved to vite.config.js... }
+		}),
+		package: {
+			// strip test files from packaging
+			files: (filepath) => {
+				return filepath.indexOf('test') == -1 ? true : false
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
Looking at https://kit.svelte.dev/docs/configuration#package

Their docs are wrong - it needs to be nested under kit.package: and the '!**/build.*' exclude is nonsense as they never get sent to that function on either build or package.  Have changed this to a JS only implementation.

This closes #127 