### PR TITLE
Decoupled Highlight.js from CodeBlock component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,5 @@
 		"vitest": "^0.19.1"
 	},
 	"type": "module",
-	"types": "index.d.ts",
-	"dependencies": {
-		"highlight.js": "^11.6.0"
-	}
+	"types": "index.d.ts"
 }

--- a/src/lib/CodeBlock/CodeBlock.svelte
+++ b/src/lib/CodeBlock/CodeBlock.svelte
@@ -1,5 +1,8 @@
+<!-- NOTE: don't allow linting on this page as pre/code tags are particular about whitespace -->
+<!-- prettier-ignore-start -->
+
 <script lang="ts">
-	import hljs from 'highlight.js';
+	import { storeHighlightJs } from '$lib/CodeBlock/stores';
 
 	export let language: string = 'plaintext';
 	export let code: string = '';
@@ -9,21 +12,29 @@
 	let cBaseBlock: string = `text-surface-50 p-4 rounded`;
 	let cBaseHeader: string = 'text-xs opacity-50 pb-2';
 
+	// Allow shorthand 'js' alias for Javascript
 	function languageFormatter(lang: string): string {
-		if (lang === 'js') {
-			return 'javascript';
-		}
+		if (lang === 'js') { return 'javascript'; }
 		return lang;
 	}
+
+	// Trigger syntax highlighting if highlight.js is available
+	function highlight(): void {
+		if ($storeHighlightJs === undefined) return;
+		// Apply Highlight.js syntaxt highlighting
+		code = $storeHighlightJs.highlight(code, { language }).value;
+	}
+	highlight();
 
 	// Reactive Classes
 	$: classesBlock = `${cBaseBlock} ${background}`;
 </script>
 
 {#if language && code}
-	<div class="codeblock {classesBlock} {$$props.class}" data-testid="codeblock">
-		<header class={cBaseHeader}>{languageFormatter(language)}</header>
-		<!-- prettier-ignore -->
-		<pre class="whitespace-pre-wrap break-all text-sm"><code class="language-{language} outline-none" contenteditable spellcheck="false">{@html hljs.highlight(code, { language }).value || code}</code></pre>
-	</div>
+<div class="codeblock {classesBlock} {$$props.class}" data-testid="codeblock">
+<header class={cBaseHeader}>{languageFormatter(language)}</header>
+<pre class="whitespace-pre-wrap break-all text-sm"><code class="language-{language} outline-none" contenteditable spellcheck="false">{@html code}</code></pre>
+</div>
 {/if}
+
+<!-- prettier-ignore-end -->

--- a/src/lib/CodeBlock/stores.ts
+++ b/src/lib/CodeBlock/stores.ts
@@ -1,0 +1,5 @@
+import { writable, type Writable } from "svelte/store";
+
+export const storeHighlightJs: Writable<any> = writable(undefined);
+
+// TODO: add support for other highlighters here in the future

--- a/src/lib/Table/DataTable.svelte
+++ b/src/lib/Table/DataTable.svelte
@@ -97,32 +97,20 @@
 	}
 
 	// A11y Input Handler
+	// prettier-ignore
 	function onKeyDown(event: any): void {
 		// Arrow Keys
 		const hotKeys: string[] = ['ArrowRight', 'ArrowUp', 'ArrowLeft', 'ArrowDown', 'Home', 'End'];
 		if (hotKeys.includes(event.code)) {
 			event.preventDefault();
 			switch (event.code) {
-				case 'ArrowUp':
-					setActiveCell(0, -1);
-					break;
-				case 'ArrowDown':
-					setActiveCell(0, 1);
-					break;
-				case 'ArrowLeft':
-					setActiveCell(-1, 0);
-					break;
-				case 'ArrowRight':
-					setActiveCell(1, 0);
-					break;
-				case 'Home':
-					jumpToFirstColumn();
-					break;
-				case 'End':
-					jumpToLastColumn();
-					break;
-				default:
-					break;
+				case 'ArrowUp': setActiveCell(0, -1); break;
+				case 'ArrowDown': setActiveCell(0, 1); break;
+				case 'ArrowLeft': setActiveCell(-1, 0); break;
+				case 'ArrowRight': setActiveCell(1, 0); break;
+				case 'Home': jumpToFirstColumn(); break;
+				case 'End': jumpToLastColumn(); break;
+				default: break;
 			}
 		}
 	}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,11 +11,9 @@ export { default as Breadcrumb } from './Breadcrumb/Breadcrumb.svelte';
 export { default as Crumb } from './Breadcrumb/Crumb.svelte';
 export { default as Button } from './Button/Button.svelte';
 export { default as Card } from './Card/Card.svelte';
-// export { default as CodeBlock } from "./CodeBlock/CodeBlock.svelte"; // keep disabled until further notice
 export { default as Divider } from './Divider/Divider.svelte';
 export { default as Drawer } from './Drawer/Drawer.svelte';
 export { default as GradientHeading } from './GradientHeading/GradientHeading.svelte';
-export { default as LightSwitch } from './LightSwitch/LightSwitch.svelte';
 export { default as List } from './List/List.svelte';
 export { default as ListItem } from './List/ListItem.svelte';
 export { default as LogoCloud } from './LogoCloud/LogoCloud.svelte';
@@ -36,6 +34,13 @@ export { default as DataTable } from './Table/DataTable.svelte';
 export { default as Tooltip } from './Tooltip/Tooltip.svelte';
 
 // Utilities ---
+
+// LightSwitch
+export { default as LightSwitch } from './LightSwitch/LightSwitch.svelte';
+
+// CodeBlock
+export { storeHighlightJs } from './CodeBlock/stores';
+export { default as CodeBlock } from "./CodeBlock/CodeBlock.svelte";
 
 // Filters
 export { filter } from './Filters/filter';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+	import hljs from 'highlight.js';
+	import 'highlight.js/styles/github-dark.css';
+	import { storeHighlightJs } from '$lib/CodeBlock/stores';
+	storeHighlightJs.set(hljs);
+
 	import { page } from '$app/stores';
 	import { writable, type Writable } from 'svelte/store';
 	import { afterNavigate } from '$app/navigation';
@@ -6,9 +11,8 @@
 	import { Drawer, LightSwitch, Divider, List, ListItem, Button, Badge, Dialog, Toast } from '@brainandbones/skeleton';
 	import { Apollo, BlueNight, Emerald, GreenFall, Noir, NoirLight, Rustic, Summer84, XPro } from '@brainandbones/skeleton';
 	import SvgIcon from '$lib/SvgIcon/SvgIcon.svelte';
-
+	
 	// Import CSS
-	import 'highlight.js/styles/github-dark.css'; // Highlight.js
 	import '../themes/theme-skeleton.css'; // skeleton|rocket|modern|seafoam|vintage|sahara|test
 	import '../app.postcss';
 
@@ -66,7 +70,7 @@
 		{
 			title: 'Utilities',
 			list: [
-				// {href: '/utilities/codeblocks', label: 'Code Blocks'}, // keep disabled until further notice
+				{href: '/utilities/codeblocks', label: 'Code Blocks'},
 				{ href: '/utilities/dialogs', label: 'Dialogs' },
 				{ href: '/utilities/toasts', label: 'Toasts' },
 				{ href: '/utilities/lightswitches', label: 'Lightswitch' },
@@ -84,6 +88,7 @@
 		drawer.set(false);
 	};
 
+	// Lifecycle Events
 	afterNavigate(() => {
 		// Scroll to top
 		const elemMain = document.querySelector('#main');

--- a/src/routes/utilities/codeblocks/+page.svelte
+++ b/src/routes/utilities/codeblocks/+page.svelte
@@ -2,23 +2,12 @@
 	import { Card, DataTable } from '@brainandbones/skeleton';
 	import CodeBlock from '$lib/CodeBlock/CodeBlock.svelte';
 
+	// prettier-ignore
 	const tableProps: any = {
 		headings: ['Prop', 'Type', 'Values', 'Default', 'Description'],
 		source: [
-			[
-				'language',
-				'string',
-				'html | css | js | ...',
-				'plaintext',
-				'Sets a language alias: <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md" target="_blank">Highlight.js</a>'
-			],
-			[
-				'code',
-				'string',
-				'-',
-				'-',
-				'Takes a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals" target="_blank">Template Literal</a>. Be mindful to escape as needed.'
-			],
+			[ 'language', 'string', 'html | css | js | ...', 'plaintext', 'Sets a language alias: <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md" target="_blank">Highlight.js</a>' ],
+			[ 'code', 'string', '-', '-', 'Takes a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals" target="_blank">Template Literal</a>. Be mindful to escape as needed.' ],
 			['background', 'string', '(class)', 'bg-neutral-900', 'Provide a CSS class to define the background color.']
 		]
 	};
@@ -29,7 +18,7 @@
 	<header class="space-y-4">
 		<h1>Code Blocks</h1>
 		<p>
-			Displays pre-formatted source code, with built-in support for <a href="https://highlightjs.org/" target="_blank">Highlight.js</a>.
+			Displays pre-formatted source code, with optional support for <a href="https://highlightjs.org/" target="_blank">Highlight.js</a> syntax highlighting.
 		</p>
 		<CodeBlock language="javascript" code={`import { CodeBlock } from '@brainandbones/skeleton';`} />
 	</header>
@@ -43,20 +32,22 @@
 
 	<!-- Usage -->
 	<section class="space-y-4">
-		<h2>Usage</h2>
-		<p>
-			Please note that Skeleton will install <a href="https://highlightjs.org/" target="_blank">Highlight.js</a> as a dependency for this.
-		</p>
-		<h4>Add a Theme</h4>
-		<p>
-			Implement a <a href="https://github.com/highlightjs/highlight.js/tree/main/src/styles" target="_blank">Highlight.js CSS theme</a>. Add the following to your app's root component, before your
-			theme and global stylesheet import.
-		</p>
-		<CodeBlock language="js" code={`import 'highlight.js/styles/github-dark.css';`} />
-		<h3>Insert a Codeblock</h3>
-		<p>
-			Add the following anywhere you wish to display a codeblock. See the <em>properties</em> documentation below.
-		</p>
+		<h2>Setup Highlight.js</h2>
+		<p>If you wish to enable syntax highlighting, install <a href="https://highlightjs.org/" target="_blank">Highlight.js</a> as a depedency.</p>
+		<CodeBlock language="console" code={`npm install highlight.js`} />
+		<p>Add the <u>following three imports</u> to your app's root component (ex: <code>/src/routes/+layout.svelte</code> for SvelteKit).</p>
+		<CodeBlock language="typescript" code={`import hljs from 'highlight.js';`} />
+		<p>Import any <a href="https://github.com/highlightjs/highlight.js/tree/main/src/styles" target="_blank">Highlight.js CSS theme</a> of your choice.</p>
+		<CodeBlock language="typescript" code={`import 'highlight.js/styles/github-dark.css';`} />
+		<p>Finally, import the CodeBlock's writable store and pass a referenced to Highlight.js.</p>
+		<CodeBlock language="typescript" code={`import { storeHighlightJs } from '@brainandbones/skeleton';\nstoreHighlightJs.set(hljs);`} />
+		<p>This will trigger highlighting only when a supported <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md" target="_blank">language alias</a> is provided to the CodeBlock's <code>language</code> prop.</p>
+	</section>
+
+	<!-- Usage -->
+	<section class="space-y-4">
+		<h3>Usage</h3>
+		<p>Add the following anywhere you wish to display a codeblock.</p>
 		<CodeBlock code={'<CodeBlock language="html" code={`<div>This is meta</div>`}></CodeBlock>'} />
 	</section>
 


### PR DESCRIPTION
See the attached ticket for details. In short, this drops the Highlightjs dep from CodeBlock, reinstated CodeBlock, update docs. Highlight.js is now an optional progressive enchantment if you choose to add it.