### PR TITLE
Package config hoisted a level as it is it's own package now

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,12 +19,12 @@ const config = {
 			assets: 'build',
 			fallback: 'index.html', // index.html (SPA) | null (SSR)
 			precompress: false
-		}),
-		package: {
-			// strip test files from packaging
-			files: (filepath) => {
-				return filepath.indexOf('test') == -1 ? true : false
-			}
+		})
+	},
+	package: {
+		// strip test files from packaging
+		files: (filepath) => {
+			return filepath.indexOf('test') == -1 ? true : false
 		}
 	}
 };


### PR DESCRIPTION
Because @sveltejs/package is it's own package now, the config is not under the `kit` property anymore.  `pnpm i`, `pnpm package` and `pnpm test` all seem to work as before their change.  This fixes #156 