### PR TITLE
Code block syntaxhighlight bug

### DIFF
--- a/src/lib/CodeBlock/CodeBlock.svelte
+++ b/src/lib/CodeBlock/CodeBlock.svelte
@@ -9,31 +9,32 @@
 	let cBaseBlock: string = `text-surface-50 p-4 rounded`;
 	let cBaseHeader: string = 'text-xs opacity-50 pb-2';
 
+	// Notify the template to use @html injection
+	let formatted: boolean = false;
+
 	// Allow shorthand 'js' alias for Javascript
 	function languageFormatter(lang: string): string {
-		if (lang === 'js') {
-			return 'javascript';
-		}
+		if (lang === 'js') { return 'javascript'; }
 		return lang;
 	}
 
 	// Trigger syntax highlighting if highlight.js is available
 	$: if ($storeHighlightJs !== undefined) {
-		// Apply Highlight.js syntaxt highlighting
 		code = $storeHighlightJs.highlight(code, { language }).value;
+		formatted = true;
 	}
 
 	// Reactive Classes
 	$: classesBlock = `${cBaseBlock} ${background}`;
 </script>
 
-<!-- NOTE: don't allow linting on this page as pre/code tags are particular about whitespace -->
+<!-- NOTE: don't allow linting as pre/code tags are particular about whitespace -->
 <!-- prettier-ignore-start -->
 
 {#if language && code}
 <div class="codeblock {classesBlock} {$$props.class}" data-testid="codeblock">
 <header class={cBaseHeader}>{languageFormatter(language)}</header>
-<pre class="whitespace-pre-wrap break-all text-sm"><code class="language-{language} outline-none" contenteditable spellcheck="false">{#if $storeHighlightJs !== undefined}{@html code}{:else}{code}{/if}</code></pre>
+<pre class="whitespace-pre-wrap break-all text-sm"><code class="language-{language} outline-none" contenteditable spellcheck="false">{#if formatted}{@html code}{:else}{code}{/if}</code></pre>
 </div>
 {/if}
 

--- a/src/lib/CodeBlock/CodeBlock.svelte
+++ b/src/lib/CodeBlock/CodeBlock.svelte
@@ -33,7 +33,7 @@
 {#if language && code}
 <div class="codeblock {classesBlock} {$$props.class}" data-testid="codeblock">
 <header class={cBaseHeader}>{languageFormatter(language)}</header>
-<pre class="whitespace-pre-wrap break-all text-sm"><code class="language-{language} outline-none" contenteditable spellcheck="false">{@html code}</code></pre>
+<pre class="whitespace-pre-wrap break-all text-sm"><code class="language-{language} outline-none" contenteditable spellcheck="false">{#if $storeHighlightJs !== undefined}{@html code}{:else}{code}{/if}</code></pre>
 </div>
 {/if}
 

--- a/src/lib/CodeBlock/CodeBlock.svelte
+++ b/src/lib/CodeBlock/CodeBlock.svelte
@@ -1,6 +1,3 @@
-<!-- NOTE: don't allow linting on this page as pre/code tags are particular about whitespace -->
-<!-- prettier-ignore-start -->
-
 <script lang="ts">
 	import { storeHighlightJs } from '$lib/CodeBlock/stores';
 
@@ -14,21 +11,24 @@
 
 	// Allow shorthand 'js' alias for Javascript
 	function languageFormatter(lang: string): string {
-		if (lang === 'js') { return 'javascript'; }
+		if (lang === 'js') {
+			return 'javascript';
+		}
 		return lang;
 	}
 
 	// Trigger syntax highlighting if highlight.js is available
-	function highlight(): void {
-		if ($storeHighlightJs === undefined) return;
+	$: if ($storeHighlightJs !== undefined) {
 		// Apply Highlight.js syntaxt highlighting
 		code = $storeHighlightJs.highlight(code, { language }).value;
 	}
-	highlight();
 
 	// Reactive Classes
 	$: classesBlock = `${cBaseBlock} ${background}`;
 </script>
+
+<!-- NOTE: don't allow linting on this page as pre/code tags are particular about whitespace -->
+<!-- prettier-ignore-start -->
 
 {#if language && code}
 <div class="codeblock {classesBlock} {$$props.class}" data-testid="codeblock">


### PR DESCRIPTION
This PR is to address a bug that removes syntax highlighting when the content of a CodeBlock is altered, specifically in this case the Skeleton sites Theme Generator

This PR also corrects an issue with HTML when highlight.js is not installed, the HTML needs to be passed directly as text instead of HTML in the component