### PR TITLE
Removed a11y warning on Gradient Header

### DIFF
--- a/src/lib/GradientHeading/GradientHeading.svelte
+++ b/src/lib/GradientHeading/GradientHeading.svelte
@@ -11,6 +11,7 @@
 	$: classesWrapper = `${cBaseHeading} ${direction} ${from} ${to}`;
 </script>
 
+<!-- svelte-ignore a11y-role-has-required-aria-props-->
 <svelte:element this={tag} class="gradient-heading {$$props.class}" data-testid="gradient-heading" role="heading">
 	<span class={classesWrapper}>
 		<slot />


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level the proper level will be inferred from the `tag` being h1-6 or explicitly defined by the end dev.  Just added an ignore for the warning so as to not be a false positive.

This fixes #183