### PR TITLE
ListBox was Listbox at few places

### DIFF
--- a/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/src/routes/(inner)/components/listboxes/+page.svelte
@@ -63,7 +63,7 @@
 	<header class="space-y-4">
 		<h1>Listboxes</h1>
 		<p class="space-y-4">Interactive listboxes that maintain selection state.</p>
-		<CodeBlock language="js" code={`import { Listbox, ListBoxItem } from '@brainandbones/skeleton';`} />
+		<CodeBlock language="js" code={`import { ListBox, ListBoxItem } from '@brainandbones/skeleton';`} />
 	</header>
 
 	<!-- Examples -->
@@ -114,7 +114,7 @@
 		<CodeBlock
 			language="html"
 			code={`
-<ListBox selected={storeMultiple}" label="Multi-Selection">
+<ListBox selected={storeMultiple} label="Multi-Selection">
     <ListBoxItem value={'A'}>Item A</ListBoxItem>
     <ListBoxItem value={'B'}>Item B</ListBoxItem>
     <ListBoxItem value={'C'}>Item C</ListBoxItem>
@@ -126,9 +126,9 @@
 	<!-- Properties -->
 	<section class="space-y-4">
 		<h2>Properties</h2>
-		<h3>Listbox</h3>
+		<h3>ListBox</h3>
 		<DataTable headings={tablePropsList.headings} source={tablePropsList.source} />
-		<h3>Listbox Item</h3>
+		<h3>ListBox Item</h3>
 		<p>These properties can be set on the parent to affect all child items.</p>
 		<DataTable headings={tablePropsItems.headings} source={tablePropsItems.source} />
 	</section>
@@ -145,9 +145,9 @@
 			<h2>Accessibility</h2>
 			<a href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/" target="_blank">ARIA Guidelines</a>
 		</div>
-		<h3>Listbox</h3>
+		<h3>ListBox</h3>
 		<DataTable headings={tableA11yList.headings} source={tableA11yList.source} />
-		<h3>Listbox Item</h3>
+		<h3>ListBox Item</h3>
 		<DataTable headings={tableA11yItem.headings} source={tableA11yItem.source} />
 	</section>
 </div>

--- a/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/src/routes/(inner)/components/listboxes/+page.svelte
@@ -126,9 +126,9 @@
 	<!-- Properties -->
 	<section class="space-y-4">
 		<h2>Properties</h2>
-		<h3>ListBox</h3>
+		<h3>Listbox</h3>
 		<DataTable headings={tablePropsList.headings} source={tablePropsList.source} />
-		<h3>ListBox Item</h3>
+		<h3>Listbox Item</h3>
 		<p>These properties can be set on the parent to affect all child items.</p>
 		<DataTable headings={tablePropsItems.headings} source={tablePropsItems.source} />
 	</section>
@@ -145,9 +145,9 @@
 			<h2>Accessibility</h2>
 			<a href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/" target="_blank">ARIA Guidelines</a>
 		</div>
-		<h3>ListBox</h3>
+		<h3>Listbox</h3>
 		<DataTable headings={tableA11yList.headings} source={tableA11yList.source} />
-		<h3>ListBox Item</h3>
+		<h3>Listbox Item</h3>
 		<DataTable headings={tableA11yItem.headings} source={tableA11yItem.source} />
 	</section>
 </div>


### PR DESCRIPTION
Just fixed a few typos.
And normalized the use of text `Listbox` to `ListBox` in docs to avoid any confusion.