### PR TITLE
Sveld auto doc of Props and Accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"tslib": "^2.4.0",
 		"typescript": "^4.8.3",
 		"vite": "^3.1.3",
+		"vite-plugin-sveld": "^1.0.3",
 		"vitest": "^0.23.4"
 	},
 	"type": "module",

--- a/src/lib/components/Accordion/AccordionGroup.svelte
+++ b/src/lib/components/Accordion/AccordionGroup.svelte
@@ -2,11 +2,16 @@
 	import { onMount, setContext } from 'svelte';
 
 	// Props
+	/** Enable auto-collapse mode.*/
 	export let collapse: boolean = true;
 	// Props (item)
+	/** Provide classes to set the hover background color.*/
 	export let hover: string = 'bg-hover-token';
+	/** Provide classes to set vertical spacing.*/
 	export let spacing: string = 'space-y-4';
+	/** Provide classes to set padding for summary and content regions.*/
 	export let padding: string = 'px-4 py-2';
+	/** Provide classes to set summary border radius.*/
 	export let rounded: string = 'rounded-token';
 
 	// Context

--- a/src/lib/components/Accordion/AccordionItem.svelte
+++ b/src/lib/components/Accordion/AccordionItem.svelte
@@ -3,18 +3,47 @@
 	import SvgIcon from '$lib/components/SvgIcon/SvgIcon.svelte';
 
 	// Props
+	/** Defines the default open state on page load.*/
 	export let open: boolean = false;
+
 	// Props (slot)
+	/** This is the slot summary
+	 * @type { string | undefined }*/
 	export let slotSummary: string | undefined = undefined;
+	/** This is the slot content
+	 * @type { string | undefined }*/
 	export let slotContent: string | undefined = undefined;
 	// A11y
+	/** Provide semantic ID for ARIA summary element. a11y https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion
+	 * @type { string | undefined }*/
 	export let summaryId: string | undefined = undefined;
+	/** Provide semantic ID for ARIA content element. a11y https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion
+	 * @type { string | undefined }*/
 	export let contentId: string | undefined = undefined;
 
 	// Context
+	/**
+	 * @typedef PropertiesHash
+	 * @type {object}
+	 * @property {string} id - an ID.
+	 * @property {string} name - your name.
+	 * @property {number} age - your age.
+	 */
+	/** Provide classes to set the hover background color. Inherits from AccordianGroup
+	 * @type {PropertiesHash}
+	 */
 	export let hover: string = getContext('hover');
+	/** Provide classes to set spacing between title and description elements.
+	 * @type {string}
+	 */
 	export let spacing: string = getContext('spacing');
+	/** Provide classes to set padding for summary and content regions.
+	 * @type {string}
+	 */
 	export let padding: string = getContext('padding');
+	/** Provide classes to set summary border radius.
+	 * @type {string}
+	 */
 	export let rounded: string = getContext('rounded');
 
 	// Base Classes

--- a/src/routes/(inner)/components/accordions/+page.svelte
+++ b/src/routes/(inner)/components/accordions/+page.svelte
@@ -78,14 +78,14 @@
 		}
 	];
 	const a11y: DocsShellTable[] = [
-		{
-			aria: 'https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion',
-			headings: ['Prop', 'Description'],
-			source: [
-				['<code>summaryId</code>', 'Provide semantic ID for ARIA summary element.'],
-				['<code>contentId</code>', 'Provide semantic ID for ARIA content element.']
-			]
-		},
+		// {
+		// 	aria: 'https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion',
+		// 	headings: ['Prop', 'Description'],
+		// 	source: [
+		// 		['<code>summaryId</code>', 'Provide semantic ID for ARIA summary element.'],
+		// 		['<code>contentId</code>', 'Provide semantic ID for ARIA content element.']
+		// 	]
+		// },
 		{
 			label: 'Keyboard Interactions',
 			headings: ['Keys', 'Description'],
@@ -98,7 +98,7 @@
 	];
 </script>
 
-<DocsShell {settings} {properties} {classes} {slots} {a11y}>
+<DocsShell {settings} {properties} {classes} {slots} {a11y} components={["Accordion/AccordionGroup","Accordion/AccordionItem"]}>
 	<!-- Slot: Sandbox -->
 	<svelte:fragment slot="sandbox">
 		<section class="card card-body">

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { configDefaults } from 'vitest/config';
 import path from 'path';
+import sveld from 'vite-plugin-sveld';
 
 // Import package.json version
 import { readFileSync } from 'fs';
@@ -11,7 +12,7 @@ const pkg = JSON.parse(json);
 
 /** @type {import('vite').UserConfig} */
 const config = {
-	plugins: [sveltekit({ hot: !process.env.VITEST })],
+	plugins: [sveltekit({ hot: !process.env.VITEST }), sveld()],
 	define: {
 		__PACKAGE__: pkg
 	},


### PR DESCRIPTION
DO NOT MERGE - this is for previewing
## What does your PR address?

Fixes #351 

Notes: This actually uses https://github.com/mattjennings/vite-plugin-sveld which in turn uses sveld.

To differentiate between props that are Props and props that are for Accessibility, it is using magic strings in the description, if `a11y` appears in the description, it will be moved into the Accessibility tab.

To enable this for a components doc page, add `components={["Accordion/AccordionGroup","Accordion/AccordionItem"]}` to the DocsShell's props. It handles a plain string for a single component and an array of strings components.

Although it handles migrating the Props tabs over incrementally (it replaces the `props DocsShellTable`, it can't be done for Accessibility due to extraneous tables being added like KeyBindings that sveld can't detect.

I've done the Accordion components as an example to show what's needed.  They are not for publishing yet, but rather to show what's needed and how different scenarios work.

Where a type has a union of possible values, it must be declared using the `@type` directive, otherwise only the last type of the union is declared from the auto-inference.

Vite also complains mightily about doing dynamic imports like this, so some more testing needs to be done of a full published docs site.  There is a fallback option if issues arise, but it's uglier to wire up.