### PR TITLE
make consistent with dropzone

### DIFF
--- a/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -69,7 +69,7 @@
 	<svelte:fragment slot="usage">
 		<section class="space-y-4">
 			<CodeBlock language="ts" code={`let files: FileList;`} />
-			<CodeBlock language="html" code={`<FileButton bind:files={myFiles} class="btn-filled-accent">Upload File</FileButton>`} />
+			<CodeBlock language="html" code={`<FileButton bind:files={files} class="btn-filled-accent">Upload File</FileButton>`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>


### PR DESCRIPTION
quick fix to make var name consistent across drop zone and button