### PR TITLE
Base functionality needed for JSDocs

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,1 @@
+export type CSSClasses = string;


### PR DESCRIPTION
This functionality is only in the docs site and only gets activated as doc pages start adding the `components` prop on DocShell.  Just greatly simplifies progressively adding JSDocs and doc pages without having to do 3 way branch merges etc.