### PR TITLE
gitignore fixes for monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 .DS_Store
 node_modules
-/build
-/.svelte-kit
-/package
+build
+.svelte-kit
+package
 .env
 .env.*
 !.env.example
-/coverage
+coverage
 pnpm-lock.yaml
 .vscode


### PR DESCRIPTION
The leading slashes made it only work at the root level, rather than flow down into multiple projects