### PR TITLE
chore: fix broken feature request label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: 🛠️ Request New Feature
 description: Let us know what we should add.
-labels: 'feature-request'
+labels: ['feature request']
 body:
   - type: textarea
     id: description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Before submitting the PR:
 - [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/Brain-Bones/skeleton/discussions) before submission.
-- [ ] Did you you update and run tests before submission using `npm run test`?
+- [ ] Did you update and run tests before submission using `npm run test`?
 - [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
 - [ ] Did you update documentation related to your new feature or changes?
 


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/Brain-Bones/skeleton/discussions) before submission.
- [x] ~Did you update and run tests before submission using `npm run test`?~
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] ~Did you update documentation related to your new feature or changes?~

## What does your PR address?

This should fix the problem with the `feature request` label not being automatically added to new issues when creating from the template.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.