### PR TITLE
Removed ts path config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,15 +32,6 @@
 		"allowJs": true,
 		"checkJs": true,
 		"strict": true,
-		"paths": {
-			"$lib": ["src/lib"],
-			"$lib/*": ["src/lib/*"],
-			"$root": ["./"],
-			"$root/*": ["./*"],
-			"@brainandbones/skeleton": ["src/lib/index.ts"],
-			"$docs": ["src/docs"],
-			"$docs/*": ["src/docs/*"]
-		},
 		"outDir": "package"
 	}
 }


### PR DESCRIPTION
As per https://kit.svelte.dev/docs/configuration#alias the alias setting in svelte config.kit.alias now sets things up in both Vite and Typescript for us.